### PR TITLE
Image Effectastic.

### DIFF
--- a/SatelliteEyes/Defaults.plist
+++ b/SatelliteEyes/Defaults.plist
@@ -101,10 +101,87 @@
 			<integer>17</integer>
 		</dict>
 	</array>
+	<key>imageEffectTypes</key>
+	<array>
+		<dict>
+			<key>id</key>
+			<string>none</string>
+			<key>name</key>
+			<string>None</string>
+			<key>filters</key>
+			<array/>
+		</dict>
+		<dict>
+			<key>id</key>
+			<string>pixellate</string>
+			<key>name</key>
+			<string>Pixellate</string>
+			<key>filters</key>
+			<array>
+				<dict>
+					<key>name</key>
+					<string>CIPixellate</string>
+					<key>parameters</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>inputScale</string>
+							<key>value</key>
+							<integer>8</integer>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>id</key>
+			<string>halftone</string>
+			<key>name</key>
+			<string>Halftone</string>
+			<key>filters</key>
+			<array>
+				<dict>
+					<key>name</key>
+					<string>CIDotScreen</string>
+					<key>parameters</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>inputWidth</string>
+							<key>value</key>
+							<integer>2</integer>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>id</key>
+			<string>desaturate</string>
+			<key>name</key>
+			<string>Desaturate</string>
+			<key>filters</key>
+			<array>
+				<dict>
+					<key>name</key>
+					<string>CIColorControls</string>
+					<key>parameters</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>inputSaturation</string>
+							<key>value</key>
+							<real>0.1</real>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+	</array>
 	<key>zoomLevel</key>
 	<integer>15</integer>
-	<key>imageEffect</key>
-	<integer>0</integer>
+	<key>selectedImageEffectId</key>
+	<string>none</string>
 	<key>selectedMapTypeId</key>
 	<string>stamen-watercolor</string>
 	<key>cleanCache</key>

--- a/SatelliteEyes/TTMapImage.h
+++ b/SatelliteEyes/TTMapImage.h
@@ -11,18 +11,11 @@
 
 #define TILE_SIZE 256
 
-typedef enum {
-    TTNoImageEffect = 0,
-    TTPixellateImageEffect = 1,
-    TTDotScreenImageEffect = 2,
-    TTAtkinsonDitherImageEffect = 3
-} TTMapImageEffect;
-
 @interface TTMapImage : NSObject {
     CGRect tileRect;
     unsigned short zoomLevel;
     NSString *source;
-    TTMapImageEffect imageEffect;
+    NSDictionary *imageEffect;
     NSArray *tiles;
     CGPoint pixelShift;
     NSOperationQueue *tileQueue;
@@ -32,7 +25,7 @@ typedef enum {
 - (id)initWithTileRect:(CGRect)_tileRect 
              zoomLevel:(unsigned short)_zoomLevel
                 source:(NSString *)_provider
-                effect:(TTMapImageEffect)_effect
+                effect:(NSDictionary *)_effect
                   logo:(NSImage *)logoImage;
 
 - (void)fetchTilesWithSuccess:(void (^)(NSURL *filePath))success

--- a/SatelliteEyes/TTMapManager.h
+++ b/SatelliteEyes/TTMapManager.h
@@ -36,6 +36,6 @@ static NSString *const TTMapManagerLocationPermissionDenied = @"TTMapManagerLoca
 @property (readonly) short unsigned int zoomLevel;
 @property (readonly) NSDictionary *selectedMapType;
 @property (readonly) NSImage *logoImage;
-@property (readonly) TTMapImageEffect imageEffect;
+@property (readonly) NSDictionary *selectedImageEffect;
 
 @end

--- a/SatelliteEyes/TTMapManager.m
+++ b/SatelliteEyes/TTMapManager.m
@@ -62,7 +62,7 @@
                                                    context:nil];
         
         [[NSUserDefaults standardUserDefaults] addObserver:self 
-                                                forKeyPath:@"imageEffect" 
+                                                forKeyPath:@"selectedImageEffectId"
                                                    options:NSKeyValueObservingOptionNew
                                                    context:nil];
 
@@ -152,7 +152,7 @@
             [[TTMapImage alloc] initWithTileRect:tileRect
                                        zoomLevel:self.zoomLevel
                                           source:self.source
-                                          effect:self.imageEffect
+                                          effect:self.selectedImageEffect
                                             logo:self.logoImage];
             
             [mapImage fetchTilesWithSuccess:^(NSURL *filePath) {
@@ -241,9 +241,24 @@
     return CGRectMake(targetScreenTileOriginX, targetScreenTileOriginY, targetScreenTileWidth, targetScreenTileHeight);
 }
 
-- (TTMapImageEffect)imageEffect {
-    NSNumber *imageEffectNumber = [[NSUserDefaults standardUserDefaults] objectForKey:@"imageEffect"];
-    return [imageEffectNumber intValue];
+- (NSDictionary *)selectedImageEffect {
+    NSArray *imageEffects = [[NSUserDefaults standardUserDefaults] objectForKey:@"imageEffectTypes"];
+    NSString *selectedImageEffectId = [[NSUserDefaults standardUserDefaults] objectForKey:@"selectedImageEffectId"];
+
+    // Default to the first image effect
+    __block NSDictionary *selectedImageEffect = [imageEffects objectAtIndex:0];
+    
+    // Now try and find a matching image effect type id, and set that to be the selected one
+    [imageEffects enumerateObjectsUsingBlock:^(NSDictionary *imageEffect, NSUInteger idx, BOOL *stop) {
+        NSString *imageEffectId = [imageEffect objectForKey:@"id"];
+        
+        if ([imageEffectId isEqualToString:selectedImageEffectId]) {
+            selectedImageEffect = imageEffect;
+            *stop = YES;
+        }
+    }];
+    
+    return selectedImageEffect;
 }
 
 - (NSString *)source {
@@ -371,7 +386,7 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:@"selectedMapTypeIndex"];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:@"zoomLevel"];
-    [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:@"imageEffect"];
+    [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:@"selectedImageEffectId"];
     [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
 }
 

--- a/SatelliteEyes/TTPreferencesWindow.xib
+++ b/SatelliteEyes/TTPreferencesWindow.xib
@@ -129,7 +129,6 @@
 									</array>
 									<reference key="NSMenuFont" ref="112955984"/>
 								</object>
-								<int key="NSSelectedIndex">-1</int>
 								<int key="NSPreferredEdge">1</int>
 								<bool key="NSUsesItemFromMenu">YES</bool>
 								<bool key="NSAltersState">YES</bool>
@@ -322,23 +321,22 @@
 								<string key="NSKeyEquivalent"/>
 								<int key="NSPeriodicDelay">400</int>
 								<int key="NSPeriodicInterval">75</int>
-								<object class="NSMenuItem" key="NSMenuItem" id="1008142738">
-									<reference key="NSMenu" ref="382460510"/>
-									<string key="NSTitle">None</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<int key="NSState">1</int>
-									<reference key="NSOnImage" ref="244926933"/>
-									<reference key="NSMixedImage" ref="2387339"/>
-									<string key="NSAction">_popUpItemAction:</string>
-									<reference key="NSTarget" ref="787578515"/>
-								</object>
+								<nil key="NSMenuItem"/>
 								<bool key="NSMenuItemRespectAlignment">YES</bool>
 								<object class="NSMenu" key="NSMenu" id="382460510">
 									<string key="NSTitle">OtherViews</string>
 									<array class="NSMutableArray" key="NSMenuItems">
-										<reference ref="1008142738"/>
+										<object class="NSMenuItem" id="1008142738">
+											<reference key="NSMenu" ref="382460510"/>
+											<string key="NSTitle">None</string>
+											<string key="NSKeyEquiv"/>
+											<int key="NSKeyEquivModMask">1048576</int>
+											<int key="NSMnemonicLoc">2147483647</int>
+											<reference key="NSOnImage" ref="244926933"/>
+											<reference key="NSMixedImage" ref="2387339"/>
+											<string key="NSAction">_popUpItemAction:</string>
+											<reference key="NSTarget" ref="787578515"/>
+										</object>
 										<object class="NSMenuItem" id="283098658">
 											<reference key="NSMenu" ref="382460510"/>
 											<string key="NSTitle">Pixellate</string>
@@ -556,19 +554,70 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
-						<string key="label">selectedTag: values.imageEffect</string>
+						<string key="label">content: values.imageEffectTypes</string>
+						<reference key="source" ref="606765555"/>
+						<reference key="destination" ref="819849576"/>
+						<object class="NSNibBindingConnector" key="connector" id="1061834234">
+							<reference key="NSSource" ref="606765555"/>
+							<reference key="NSDestination" ref="819849576"/>
+							<string key="NSLabel">content: values.imageEffectTypes</string>
+							<string key="NSBinding">content</string>
+							<string key="NSKeyPath">values.imageEffectTypes</string>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">354</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">contentObjects: values.imageEffectTypes.id</string>
+						<reference key="source" ref="606765555"/>
+						<reference key="destination" ref="819849576"/>
+						<object class="NSNibBindingConnector" key="connector" id="853095924">
+							<reference key="NSSource" ref="606765555"/>
+							<reference key="NSDestination" ref="819849576"/>
+							<string key="NSLabel">contentObjects: values.imageEffectTypes.id</string>
+							<string key="NSBinding">contentObjects</string>
+							<string key="NSKeyPath">values.imageEffectTypes.id</string>
+							<reference key="NSPreviousConnector" ref="1061834234"/>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">358</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">contentValues: values.imageEffectTypes.name</string>
+						<reference key="source" ref="606765555"/>
+						<reference key="destination" ref="819849576"/>
+						<object class="NSNibBindingConnector" key="connector" id="800739344">
+							<reference key="NSSource" ref="606765555"/>
+							<reference key="NSDestination" ref="819849576"/>
+							<string key="NSLabel">contentValues: values.imageEffectTypes.name</string>
+							<string key="NSBinding">contentValues</string>
+							<string key="NSKeyPath">values.imageEffectTypes.name</string>
+							<reference key="NSPreviousConnector" ref="853095924"/>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">370</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">selectedObject: values.selectedImageEffectId</string>
 						<reference key="source" ref="606765555"/>
 						<reference key="destination" ref="819849576"/>
 						<object class="NSNibBindingConnector" key="connector">
 							<reference key="NSSource" ref="606765555"/>
 							<reference key="NSDestination" ref="819849576"/>
-							<string key="NSLabel">selectedTag: values.imageEffect</string>
-							<string key="NSBinding">selectedTag</string>
-							<string key="NSKeyPath">values.imageEffect</string>
+							<string key="NSLabel">selectedObject: values.selectedImageEffectId</string>
+							<string key="NSBinding">selectedObject</string>
+							<string key="NSKeyPath">values.selectedImageEffectId</string>
+							<reference key="NSPreviousConnector" ref="800739344"/>
 							<int key="NSNibBindingConnectorVersion">2</int>
 						</object>
 					</object>
-					<int key="connectionID">143</int>
+					<int key="connectionID">373</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
@@ -631,8 +680,8 @@
 							<reference ref="177571657"/>
 							<reference ref="872438"/>
 							<reference ref="119413481"/>
-							<reference ref="606765555"/>
 							<reference ref="668855721"/>
+							<reference ref="606765555"/>
 						</array>
 						<reference key="parent" ref="1005"/>
 					</object>
@@ -887,7 +936,7 @@
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">349</int>
+			<int key="maxID">373</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">


### PR DESCRIPTION
Because how awesome is this?

![Stamen Watercolor + Desaturate](https://f.cloud.github.com/assets/53660/100109/a0947cac-67ec-11e2-8c7f-4462d92fc614.png)

... and this:

![Bing Aerial + Gloom](https://f.cloud.github.com/assets/53660/100113/1f868370-67ed-11e2-86ff-792f157f0b8c.png)

... and this?

![Stamen Terrain + Vibrance + Gaussian Blur](https://f.cloud.github.com/assets/53660/100171/09c6bf0a-67f2-11e2-9f05-85497c2dfe90.png)
- Store image effect definitions in NSUserDefaults, allowing user overrides and easier definition.
- Image effects define an array of filters, allowing filter composition.
- Add a "desaturate" image effect.
- Use a new defaults key (selectedImageEffectId) since the old key was an integer.
- Use an affine clamp before applying filters (so that gaussian blur and gloom type filters don't look awful).
