### PR TITLE
Add a dark 'blueprint' effect

### DIFF
--- a/SatelliteEyes/Defaults.plist
+++ b/SatelliteEyes/Defaults.plist
@@ -197,6 +197,75 @@
 	<array>
 		<dict>
 			<key>id</key>
+			<string>blueprint</string>
+			<key>name</key>
+			<string>Blueprint</string>
+			<key>disableAffineClamp</key>
+			<true/>
+			<key>filters</key>
+			<array>
+				<dict>
+					<key>name</key>
+					<string>CIColorInvert</string>
+					<key>parameters</key>
+					<array/>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>CIFalseColor</string>
+					<key>parameters</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>inputColor0</string>
+							<key>value</key>
+							<dict>
+								<key>red</key>
+								<real>0.1</real>
+								<key>green</key>
+								<real>0.1</real>
+								<key>blue</key>
+								<real>0.2</real>
+							</dict>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>inputColor1</string>
+							<key>value</key>
+							<dict>
+								<key>red</key>
+								<integer>0</integer>
+								<key>green</key>
+								<real>0.25</real>
+								<key>blue</key>
+								<real>0.5</real>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>CIVignette</string>
+					<key>parameters</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>inputRadius</string>
+							<key>value</key>
+							<integer>2</integer>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>inputIntensity</string>
+							<key>value</key>
+							<real>0.5</real>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>id</key>
 			<string>none</string>
 			<key>name</key>
 			<string>None</string>


### PR DESCRIPTION
Inverts the image, applies false colour and a vingette.

* TTMapImage gains the ability to read colours from the filters in the defaults array.
* TTMapImage respects a boolean key `disableAffineClamp` in the filter dictionary. Vignette doesn't work with AffineClamp in place.

Preview:
![map-97065e939d5f97c95af4986b66c9f697](https://cloud.githubusercontent.com/assets/421031/5072945/2ad85262-6e76-11e4-9e9a-5ba15fbc6d71.png)

Ref tomtaylor/satellite-eyes#34