### PR TITLE
updated README: elaborated on how to build it for debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ you'll work it out.
 
 To build for Debug:
 
-1. Create a new Code Signing cert named "Mac Developer". If you don't have a Mac
-   developer account and can't create a cert, you can disable code signing for
-   local development. To do this, under Build Settings, set "Code Signing
-   Identity" to "Don't Code Sign" for the Debug configuration on both the
-   SatelliteEyes and LaunchAtLoginHelper targets.
+1. Create a new Code Signing cert named "Mac Developer". 
+
+    If you don't have a Mac developer account and can't create a cert, you can disable code signing for local development. To do this, under Build Settings, set "Code Signing Identity" to "Don't Code Sign" for the Debug configuration on both the SatelliteEyes and LaunchAtLoginHelper targets. And you would also need to remove "Sign Sparkle.framework" from Build Phases.
 
 2. Set up the LaunchAtLoginHelper:
    
@@ -31,7 +29,15 @@ To build for Debug:
    python setup.py satelliteeyes uk.co.tomtaylor.SatelliteEyes
    ```
 
-3. Build!
+3. Update project dependencies & create `SatelliteEyes.xcworkspace` using [CocoaPods](https://cocoapods.org/)
+   
+    ```bash
+   pod install
+   ```
+  
+   (Install CocoaPods if you haven't: `sudo gem install cocoapods`.)
+
+4. Open `SatelliteEyes.xcworkspace` & Build!
 
 Thanks
 --


### PR DESCRIPTION
I am not enrolled as a Mac Developer & I wasn't able to build it for debug until I removed "Sign Sparkle.framework" from Build Phases & build it in `.xcworkspace`.