### PR TITLE
Fix Mapbox run-bike-hike (no labels) on non-Retina displays

### DIFF
--- a/SatelliteEyes/Defaults.plist
+++ b/SatelliteEyes/Defaults.plist
@@ -152,7 +152,7 @@
 			<key>id</key>
 			<string>mapbox-run-bike-hike-no-labels</string>
 			<key>source</key>
-			<string>https://api.tiles.mapbox.com/v4/tomtaylorb33de4c7/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoidG9tdGF5bG9yIiwiYSI6InJvYVktQ28ifQ.ra6A1XqlDa0B6yreKI2VYg</string>
+			<string>https://api.tiles.mapbox.com/v4/tomtaylor.b33de4c7/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoidG9tdGF5bG9yIiwiYSI6InJvYVktQ28ifQ.ra6A1XqlDa0B6yreKI2VYg</string>
 			<key>source2x</key>
 			<string>https://api.tiles.mapbox.com/v4/tomtaylor.b33de4c7/{z}/{x}/{y}@2x.png?access_token=pk.eyJ1IjoidG9tdGF5bG9yIiwiYSI6InJvYVktQ28ifQ.ra6A1XqlDa0B6yreKI2VYg</string>
 			<key>name</key>


### PR DESCRIPTION
The 1x source contained a typo, resulting in "There was a problem updating the map" for non-Retina displays.

This made me sad, because I like that map source.