### PR TITLE
Add 300m distance threshold for location-driven map updates

### DIFF
--- a/SatelliteEyes/MapManager.swift
+++ b/SatelliteEyes/MapManager.swift
@@ -22,6 +22,7 @@ class MapManager: NSObject, CLLocationManagerDelegate {
 
     private let locationManager = CLLocationManager()
     private var lastSeenLocation: CLLocation?
+    private var lastMapUpdateLocation: CLLocation?
     private let updateQueue = DispatchQueue(label: "uk.co.tomtaylor.satelliteeyes.mapupdate")
     private let pathMonitor = NWPathMonitor()
     private var networkSatisfied = false
@@ -243,6 +244,13 @@ class MapManager: NSObject, CLLocationManagerDelegate {
 
         NotificationCenter.default.post(name: Self.locationUpdatedNotification, object: newLocation)
         lastSeenLocation = newLocation
+
+        if let last = lastMapUpdateLocation,
+           newLocation.distance(from: last) < 300 {
+            return
+        }
+
+        lastMapUpdateLocation = newLocation
         updateMap(to: newLocation.coordinate, force: false)
     }
 
@@ -303,6 +311,7 @@ class MapManager: NSObject, CLLocationManagerDelegate {
         if useCurrentLocation {
             locationManager.stopUpdatingLocation()
             lastSeenLocation = nil
+            lastMapUpdateLocation = nil
             NotificationCenter.default.post(name: Self.locationLostNotification, object: nil)
             locationManager.startUpdatingLocation()
         } else {
@@ -320,6 +329,7 @@ class MapManager: NSObject, CLLocationManagerDelegate {
             rotationTimer = nil
             currentRandomLocation = nil
             lastSeenLocation = nil
+            lastMapUpdateLocation = nil
             NotificationCenter.default.post(name: Self.locationLostNotification, object: nil)
 
             guard CLLocationManager.locationServicesEnabled() else {


### PR DESCRIPTION
- Adds an application-level 300m distance check in `locationManager(_:didUpdateLocations:)` so the map only re-renders when the user has meaningfully moved, since CoreLocation's `distanceFilter` is a hint and the OS may deliver updates more frequently.
- Tracks the last location used for a map update in a new `lastMapUpdateLocation` property, which is reset on wake and location mode changes so those triggers always re-render.
- Non-location triggers (preference changes, screen changes, network reconnection) are unaffected.