### PR TITLE
Updated app to enable light/dark mode image effects

### DIFF
--- a/SatelliteEyes/Defaults.plist
+++ b/SatelliteEyes/Defaults.plist
@@ -289,6 +289,10 @@
 	<integer>15</integer>
 	<key>selectedImageEffectId</key>
 	<string>none</string>
+	<key>selectedImageEffectIdLight</key>
+	<string>none</string>
+	<key>selectedImageEffectIdDark</key>
+	<string>darken</string>
 	<key>selectedMapTypeId</key>
 	<string>google-satellite</string>
 	<key>cleanCache</key>

--- a/SatelliteEyes/MapManager.swift
+++ b/SatelliteEyes/MapManager.swift
@@ -71,9 +71,15 @@ class MapManager: NSObject, CLLocationManagerDelegate {
         UserDefaults.standard.addObserver(self, forKeyPath: "selectedMapTypeId", options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: "zoomLevel", options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: "selectedImageEffectId", options: .new, context: nil)
+        UserDefaults.standard.addObserver(self, forKeyPath: "selectedImageEffectIdLight", options: .new, context: nil)
+        UserDefaults.standard.addObserver(self, forKeyPath: "selectedImageEffectIdDark", options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: "useCurrentLocation", options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: "randomLocationCategory", options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: "rotationIntervalSeconds", options: .new, context: nil)
+
+        DistributedNotificationCenter.default().addObserver(
+            self, selector: #selector(appearanceChanged),
+            name: NSNotification.Name("AppleInterfaceThemeChangedNotification"), object: nil)
 
         NSWorkspace.shared.notificationCenter.addObserver(
             self, selector: #selector(spaceChanged),
@@ -87,9 +93,12 @@ class MapManager: NSObject, CLLocationManagerDelegate {
     deinit {
         pathMonitor.cancel()
         NotificationCenter.default.removeObserver(self)
+        DistributedNotificationCenter.default().removeObserver(self)
         UserDefaults.standard.removeObserver(self, forKeyPath: "selectedMapTypeId")
         UserDefaults.standard.removeObserver(self, forKeyPath: "zoomLevel")
         UserDefaults.standard.removeObserver(self, forKeyPath: "selectedImageEffectId")
+        UserDefaults.standard.removeObserver(self, forKeyPath: "selectedImageEffectIdLight")
+        UserDefaults.standard.removeObserver(self, forKeyPath: "selectedImageEffectIdDark")
         UserDefaults.standard.removeObserver(self, forKeyPath: "useCurrentLocation")
         UserDefaults.standard.removeObserver(self, forKeyPath: "randomLocationCategory")
         UserDefaults.standard.removeObserver(self, forKeyPath: "rotationIntervalSeconds")
@@ -298,6 +307,7 @@ class MapManager: NSObject, CLLocationManagerDelegate {
     @objc private func screensChanged(_ notification: Notification) { updateMap() }
     @objc private func spaceChanged(_ notification: Notification) { updateMap() }
     @objc private func receiveWakeNote(_ notification: Notification) { restartMap() }
+    @objc private func appearanceChanged(_ notification: Notification) { updateMap() }
 
     private func restartMap() {
         if useCurrentLocation {
@@ -387,7 +397,16 @@ class MapManager: NSObject, CLLocationManagerDelegate {
 
     private var selectedImageEffect: NSDictionary {
         let effects = UserDefaults.standard.array(forKey: "imageEffectTypes") as? [NSDictionary] ?? []
-        let selectedId = UserDefaults.standard.string(forKey: "selectedImageEffectId")
+
+        // Determine which effect ID to use based on system appearance
+        let selectedId: String?
+        let appearanceName = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
+        if appearanceName == .darkAqua {
+            selectedId = UserDefaults.standard.string(forKey: "selectedImageEffectIdDark")
+        } else {
+            selectedId = UserDefaults.standard.string(forKey: "selectedImageEffectIdLight")
+        }
+
         return effects.first { ($0["id"] as? String) == selectedId } ?? effects.first ?? [:]
     }
 

--- a/SatelliteEyes/MapManager.swift
+++ b/SatelliteEyes/MapManager.swift
@@ -116,7 +116,14 @@ class MapManager: NSObject, CLLocationManagerDelegate {
                 NotificationCenter.default.post(name: Self.locationPermissionDeniedNotification, object: nil)
                 return
             }
-            locationManager.startUpdatingLocation()
+
+            // Request authorization if needed, otherwise start updating
+            let status = locationManager.authorizationStatus
+            if status == .notDetermined {
+                locationManager.requestAlwaysAuthorization()
+            } else if status == .authorizedAlways {
+                locationManager.startUpdatingLocation()
+            }
         } else {
             pickRandomLocationAndUpdate()
             scheduleRotationTimer()

--- a/SatelliteEyes/PreferencesWindowController.swift
+++ b/SatelliteEyes/PreferencesWindowController.swift
@@ -7,6 +7,8 @@ struct PreferencesView: View {
     @AppStorage("selectedMapTypeId") private var selectedMapTypeId = "google-satellite"
     @AppStorage("zoomLevel") private var zoomLevel = 15
     @AppStorage("selectedImageEffectId") private var selectedImageEffectId = "none"
+    @AppStorage("selectedImageEffectIdLight") private var selectedImageEffectIdLight = "none"
+    @AppStorage("selectedImageEffectIdDark") private var selectedImageEffectIdDark = "darken"
     @AppStorage("useCurrentLocation") private var useCurrentLocation = true
     @AppStorage("randomLocationCategory") private var randomLocationCategory = ""
     @AppStorage("rotationIntervalSeconds") private var rotationIntervalSeconds = 86400
@@ -96,8 +98,16 @@ struct PreferencesView: View {
                     Text("\(level)").tag(level)
                 }
             }
+            .padding(.bottom, 16)
 
-            Picker("Image Effect:", selection: $selectedImageEffectId) {
+            Picker("Image Effect (Light Mode):", selection: $selectedImageEffectIdLight) {
+                ForEach(imageEffects, id: \.effectId) { effect in
+                    Text(effect["name"] as? String ?? "Unknown")
+                        .tag(effect["id"] as? String ?? "")
+                }
+            }
+
+            Picker("Image Effect (Dark Mode):", selection: $selectedImageEffectIdDark) {
                 ForEach(imageEffects, id: \.effectId) { effect in
                     Text(effect["name"] as? String ?? "Unknown")
                         .tag(effect["id"] as? String ?? "")

--- a/SatelliteEyes/SatelliteEyes-Info.plist
+++ b/SatelliteEyes/SatelliteEyes-Info.plist
@@ -47,6 +47,10 @@
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Satellite Eyes uses your location to set your desktop wallpaper to a map or satellite view of your current location.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Satellite Eyes uses your location to set your desktop wallpaper to a map or satellite view of your current location.</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUEnableSystemProfiling</key>

--- a/SatelliteEyes/SatelliteEyes-Info.plist
+++ b/SatelliteEyes/SatelliteEyes-Info.plist
@@ -47,7 +47,7 @@
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
-	<key>NSLocationWhenInUseUsageDescription</key>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Satellite Eyes uses your location to set your desktop wallpaper to a map or satellite view of your current location.</string>
 	<key>NSLocationUsageDescription</key>
 	<string>Satellite Eyes uses your location to set your desktop wallpaper to a map or satellite view of your current location.</string>


### PR DESCRIPTION
I'll admit I used some Claude help to enable the UI to show pickers for light and dark mode image effects.  Tested on my machine and it works (I use the wonderful [Nightfall app](https://github.com/r-thomson/Nightfall) to toggle between the two.

Delete this if the code is junk- just got excited when it worked.